### PR TITLE
Gem::Specification.load causes "No such file or directory - git" error at run time

### DIFF
--- a/aws-ssm-console.gemspec
+++ b/aws-ssm-console.gemspec
@@ -1,6 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'aws-sdk'
 require 'aws/ssm/console/version'
 
 Gem::Specification.new do |spec|

--- a/aws-ssm-console.gemspec
+++ b/aws-ssm-console.gemspec
@@ -1,10 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'aws/ssm/console/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'aws-ssm-console'
-  spec.version       = '0.2.2'
+  spec.version       = Aws::SSM::Console::VERSION
   spec.authors       = ['koshigoe']
   spec.email         = ['koshigoeb@gmail.com']
   spec.license       = 'MIT'

--- a/aws-ssm-console.gemspec
+++ b/aws-ssm-console.gemspec
@@ -1,12 +1,14 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'aws-sdk'
-require 'aws/ssm/console/version'
+m = Module.new do
+  module self::Anonymous
+    lib = File.expand_path('../lib', __FILE__)
+    eval File.read "#{lib}/aws/ssm/console/version.rb"
+  end
+end
 
 Gem::Specification.new do |spec|
   spec.name          = 'aws-ssm-console'
-  spec.version       = Aws::SSM::Console::VERSION
+  spec.version       = m::Anonymous::Aws::SSM::Console::VERSION
   spec.authors       = ['koshigoe']
   spec.email         = ['koshigoeb@gmail.com']
   spec.license       = 'MIT'

--- a/lib/aws/ssm/console/version.rb
+++ b/lib/aws/ssm/console/version.rb
@@ -1,9 +1,7 @@
 module Aws
   module SSM
     module Console
-      GEMSPEC_PATH = File.expand_path('../../../../../aws-ssm-console.gemspec', __FILE__)
-      GEMSPEC = Gem::Specification.load(GEMSPEC_PATH)
-      VERSION = GEMSPEC.version.to_s.freeze
+      VERSION = '0.2.2'.freeze
     end
   end
 end


### PR DESCRIPTION
```
$ docker run -it ruby:slim bash
root@b17daa5fc5bc:/# gem install aws-ssm-console
Fetching: jmespath-1.3.1.gem (100%)
Successfully installed jmespath-1.3.1
Fetching: aws-sigv4-1.0.0.gem (100%)
Successfully installed aws-sigv4-1.0.0
Fetching: aws-sdk-core-2.6.39.gem (100%)
Successfully installed aws-sdk-core-2.6.39
Fetching: aws-sdk-resources-2.6.39.gem (100%)
Successfully installed aws-sdk-resources-2.6.39
Fetching: aws-sdk-2.6.39.gem (100%)
Successfully installed aws-sdk-2.6.39
Fetching: aws-ssm-console-0.2.2.gem (100%)
Successfully installed aws-ssm-console-0.2.2
6 gems installed
root@b17daa5fc5bc:/# aws-ssm-console -h
Invalid gemspec in [/usr/local/bundle/gems/aws-ssm-console-0.2.2/aws-ssm-console.gemspec]: No such file or directory - git
/usr/local/bundle/gems/aws-ssm-console-0.2.2/lib/aws/ssm/console/version.rb:6:in `<module:Console>': undefined method `version' for nil:NilClass (NoMethodError)
	from /usr/local/bundle/gems/aws-ssm-console-0.2.2/lib/aws/ssm/console/version.rb:3:in `<module:SSM>'
	from /usr/local/bundle/gems/aws-ssm-console-0.2.2/lib/aws/ssm/console/version.rb:2:in `<module:Aws>'
	from /usr/local/bundle/gems/aws-ssm-console-0.2.2/lib/aws/ssm/console/version.rb:1:in `<top (required)>'
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bundle/gems/aws-ssm-console-0.2.2/lib/aws/ssm/console.rb:2:in `<top (required)>'
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bundle/gems/aws-ssm-console-0.2.2/exe/aws-ssm-console:6:in `<top (required)>'
	from /usr/local/bundle/bin/aws-ssm-console:22:in `load'
	from /usr/local/bundle/bin/aws-ssm-console:22:in `<main>'
```